### PR TITLE
Changes to be committed:

### DIFF
--- a/scripts/appendKPaths.py
+++ b/scripts/appendKPaths.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import sys, json
+import sys
 from ssptools.kpaths import read, makeCoordList
 
 pointList, numList, nameList = read(sys.argv[1])

--- a/scripts/compareEV.py
+++ b/scripts/compareEV.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import sys
-from pymatgen.io.vasp.outputs import Vasprun
-from ssptools.compare import compareEV
+from ssptools.io.main import readXML, getBands
+from ssptools.eigenvalues import compareEV
 
 print("Compares bands of sys.argv[1] and sys.argv[2] for the first nk kpoints where nk is the number of kpoints in sys.argv[1].\nUse as\n\tpython compareEV.py <filename of 1st vasprun.xml> <filename of 2nd vasprun.xml>")
-data1, data2 = Vasprun(sys.argv[1]).as_dict(), Vasprun(sys.argv[2]).as_dict()
+data1, data2 = getBands(readXML(sys.argv[1])), getBands(readXML(sys.argv[2]))
 print(compareEV(data1, data2))

--- a/scripts/plotBS.py
+++ b/scripts/plotBS.py
@@ -2,12 +2,16 @@
 
 import sys, json
 import matplotlib.pyplot as plt
+from matplotlib.ticker import (MultipleLocator, FormatStrFormatter, AutoMinorLocator)
 from pymatgen.io.vasp.outputs import Vasprun
+from ssptools.io.main import readXML
 from ssptools.BSData import BSData, joinBSs, openJSON
 
 nsteps = len(sys.argv)//2
 xmlFiles, jsonFiles = [sys.argv[2*n+1] for n in range(nsteps)], [sys.argv[2*n+2] for n in range(nsteps)]
-combinedData = joinBSs([BSData(Vasprun(xmlFiles[i]).as_dict(), openJSON(jsonFiles[i])) for i in range(len(xmlFiles))])
+combinedData = joinBSs([BSData(readXML(xmlFiles[i]), openJSON(jsonFiles[i]), auto_align = True) for i in range(len(xmlFiles))])
+
+x = combinedData.x_data
 
 for band in combinedData.bands:
     plt.plot(combinedData.x_data, band, color = "orange")
@@ -15,7 +19,7 @@ plt.ylim([-15, 9])
 plt.xlim([combinedData.x_data[0], combinedData.x_data[-1]])
 plt.ylabel("Energy [eV]")
 plt.xticks(ticks = combinedData.xticks, labels = combinedData.labels)
-plt.grid(axis = 'x')
+plt.grid(axis = 'both')
 plt.savefig("%s_bands.png"%combinedData.name)
 plt.show()
 plt.close()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 import setuptools
+import site
+import sys
+site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
 with open("README.md", 'r', encoding="utf-8") as fh:
 	long_description = fh.read()

--- a/ssptools/eigenvalues.py
+++ b/ssptools/eigenvalues.py
@@ -1,0 +1,60 @@
+def compareEV(bands1, bands2):
+    #bands1, bands2 = data1["output"]["eigenvalues"]['1'], data2["output"]["eigenvalues"]['1']
+    nk, nbands = len(bands1), len(bands1[0])
+    for i in range(nk):
+        for ind in range(nbands):
+            print(bands1[i][ind][0] - bands2[i][ind][0], bands1[i][ind][1] - bands2[i][ind][1])
+    return sum(sum(abs(bands1[i][ind][0] - bands2[i][ind][0]) + abs(bands1[i][ind][1] - bands2[i][ind][1]) for i in range(nk)) for ind in range(len(bands1[0])))
+
+def weighted_kpoint_inds(bands, kpts_weights):
+    return [i for i, weight in enumerate(kpts_weights) if weight != 0], [bands[i] for i, weight in enumerate(kpts_weights) if weight != 0]
+
+def seperateBands(kpoint):
+    v_bands, c_bands = [], []
+    for ev in kpoint:
+        if ev[1] == 0:
+            c_bands.append(ev[0])
+        else:
+            v_bands.append(ev[0])
+    c_bands.sort()
+    v_bands.sort(reverse = True)
+    return c_bands, v_bands
+
+def alignment(bands, **kwargs):
+    if "scheme" in kwargs.keys() and kwargs["scheme"] == "bzavg":   # eigenvalues should only inclued weighted kpoints
+        if "nvb" in kwargs.keys():
+            nvb = kwargs["nvb"]
+        else:
+            nvb = 2
+        if "ncb" in kwargs.keys():
+            ncb = kwargs["ncb"]
+        else:
+            ncb = 1
+        branchpoint = 0.
+        for kpoint in bands:
+            c_bands, v_bands = seperateBands(kpoint)
+            branchpoint += sum(c_bands[:ncb]) / ncb + sum(v_bands[:nvb]) / nvb
+        return branchpoint / (2 * len(bands))
+    else:
+        if len(bands) < 1 or max(len(kpoint) for kpoint in bands) < 1:
+            return 0
+        else:
+            occupied_states = []
+            for kpoint in bands:
+                occupied_states += [ev[0] for ev in kpoint if ev[1] != 0]
+            if len(occupied_states) < 1:
+                return 0
+            else:
+                return max(occupied_states)
+
+def gaps(bands):
+    for i, kpoint in enumerate(bands):    # first set of eigenvalues should be at gamma
+        c_bands, v_bands = seperateBands(bands[i])
+        if i == 0:
+            vmax, cmin = v_bands[0], c_bands[0]
+            direct_gap = gamma_gap = cmin - vmax
+        else:
+            vmax, cmin = max(vmax, v_bands[0]), min(cmin, c_bands[0])
+            direct_gap = min(direct_gap, c_bands[0] - v_bands[0])
+    indirect_gap = cmin - vmax
+    return gamma_gap, direct_gap, indirect_gap

--- a/ssptools/io/main.py
+++ b/ssptools/io/main.py
@@ -1,0 +1,28 @@
+import sys
+from ase.io import read, write
+from pymatgen.io.vasp.outputs import Vasprun
+import json
+
+def readXML(filename):
+    return Vasprun(filename).as_dict()
+
+def getBands(data):
+    return data['output']['eigenvalues']['1']
+
+def getKpoints(data):
+    return data['input']['kpoints']['kpoints']
+
+def getKweights(data):
+    return data['input']['kpoints']['kpts_weights']
+
+def aseRead(*argv, **kwargs):
+    read(*argv, **kwargs)
+
+def aseWrite(*argv, **kwargs):
+    write(*argv, **kwargs)
+
+def get_system(data):
+    if "SYSTEM" in data['input']['incar'].keys():
+        return data['input']['incar']['SYSTEM']
+    else:
+        return "unknown_system"


### PR DESCRIPTION
	modified:   scripts/appendKPaths.py
	modified:   scripts/compareEV.py
	modified:   scripts/plotBS.py
	modified:   setup.py
	modified:   ssptools/BSData.py
	new file:   ssptools/eigenvalues.py
	new file:   ssptools/io/__init__.py
	new file:   ssptools/io/main.py

New features:
Added io module for basic interaction with different filetypes.
Created new module eigenvalues. Contains functions to seperate bands into conduction and valence types based on occupation, to obtain band alignment and band gaps.

Changes / Improvements:
Moved function compareEV from module compare to eigenvalues and adjusted the imort accordingly in the scripts. compare is now deprecated.
Added automatic detection of band alignment strategy to BSData's initialization for structures that have "2H", "4H", "6H", "3C" in their name. For details on the strategy implemented see
Schleife, A. et al., 2009 Branch-point energies and band discontinuities of III-nitrides and III-/II-oxides from Quasiparticle Band-structure calculations. *Applied Physics Letters*, 94(1).
https://doi.org/10.1063/1.3059569
Replaced explicit calls to io functions from other modules with those in the io module.
Added horizontal grid to output of plotBS.py for easier readability. Remember that plotBS.py is for getting a basic view of the band structure. For detailed views as well as publication-worthy figures load the json generated by the script and make proper graphs.
Enabled --user flag for setup.py to prevent problems when using pip install -e (installation in development mode from source).